### PR TITLE
BayesDeBulk updated code

### DIFF
--- a/contribution_guide/README.md
+++ b/contribution_guide/README.md
@@ -1,0 +1,23 @@
+## Introduction
+
+These contribution docs will guide you through adding a novel tumor deconvolution algorithm to the evaluation platform.
+This enables developers to benchmark the performance of their algorithm.
+
+
+### Algorithm checklist
+
+Algorithms in the framework are configured with the [Common Workflow Language, CWL](#https://www.commonwl.org/user_guide/) and rely on [Docker](https://www.docker.com/) runtime environments to execute source code. 
+
+There are essentially two requirements to run a novel algorithm to the framework:
+
+- Docker image with executable source code and all pre-requisite software installed
+- CWL tool file describing expected inputs, outputs, and runtime environment
+
+### Software requirements
+
+To implement your algorithm in this framework, you will need a CWL engine and Docker installed. 
+
+- [cwltool 3.0.20210124104916^](https://github.com/common-workflow-language/cwltool)
+- [Docker](https://docs.docker.com/get-docker/)
+
+### Validating input data

--- a/tumorDeconvAlgs/BayesDeBulk/bayes-de-bulk.cwl
+++ b/tumorDeconvAlgs/BayesDeBulk/bayes-de-bulk.cwl
@@ -1,6 +1,6 @@
 #!/usr/bin/env cwl-runner
 
-# command: Rscript main.R --expressionFile=${expressionFile} --signatureMatrix=${signature_matrix}
+# command: Rscript main_docker.R --expressionFile=${expressionFile} --signatureMatrix=${signature_matrix}
 
 label: rep-bulk
 id:  rep-bulk
@@ -13,7 +13,7 @@ arguments:
 
 requirements:
   - class: DockerRequirement
-    dockerPull: tumordeconv/rep-bulk
+    dockerPull: tumordeconv/in-progress
   - class: InlineJavascriptRequirement
   
 inputs:
@@ -33,9 +33,9 @@ inputs:
       position: 3
       prefix: --rowMeansImputation
   dataType:
-     type: string
+     type: string?
   cancerType:
-     type: string
+     type: string?
 
 
 outputs:


### PR DESCRIPTION
My apologies -- I was working on the contribution-guide branch for updates to BayesDeBulk.

This PR updates the Docker image with the most recent BayesDeBulk code. The new code has been tested and runs with the CWL engine as usual.

Additional changes:
- the remote name for the BayesDeBulk image has been changed to "tumordeconv/in-progress". This is to denote the state of the algorithm and to make it less findable on Dockerhub before it is published.
- I've set dataType and cancerType to optional arguments for now, because when I was testing with toy data it raised an error otherwise



